### PR TITLE
Update django support to 5.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-countries
-version = 7.7.dev0
+version = 8.0.dev0
 description = Provides a country field for Django models.
 long_description = file: README.rst, CHANGES.rst
 author = Chris Beaven
@@ -16,17 +16,12 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Framework :: Django
-    Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
-    Framework :: Django :: 4.1
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
+    Framework :: Django :: 5.2
 project_urls =
     Change Log = https://github.com/SmileyChris/django-countries/blob/main/CHANGES.rst
     Source Code = https://github.com/SmileyChris/django-countries

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ distribute = False
 envlist =
     coverage_setup
     # Latest
+    py312-latest{-pyuca,-noi18n}
     py311-latest{-pyuca,-noi18n}
-    # Historical Python, Django and DRF versions
-    py310-previous
-    # Legacy
-    py37-legacy
+    # Current LTS
+    py312-lts
+    py311-lts
     # Package checks
     readme
     bandit
@@ -18,9 +18,8 @@ ignore_basepython_conflict = True
 
 [gh-actions]
 python =
-    3.7: py37
-    3.10: py310
     3.11: py311, readme, bandit, mypy
+    3.12: py312
 
 [testenv]
 basepython = python3
@@ -30,13 +29,11 @@ setenv =
     DJANGO_SETTINGS_MODULE = django_countries.tests.settings
 deps =
     coverage
-    legacy: djangorestframework==3.11.*
-    previous: djangorestframework==3.14.*
+    lts: djangorestframework==3.14.*
     latest: djangorestframework==3.15.*
-    pyuca,legacy: pyuca
-    legacy: Django==3.2.*
-    previous: Django==4.2.*
-    latest: Django==5.*
+    pyuca: pyuca
+    lts: Django==4.2.*
+    latest: Django==5.2.*
     latest: graphene-django==3.0.*
 depends = coverage_setup
 commands = coverage run -m pytest {posargs}
@@ -73,9 +70,10 @@ commands = coverage erase
 skip_install = True
 parallel_show_output = True
 depends =
+    py312-latest{-pyuca,-noi18n}
     py311-latest{-pyuca,-noi18n}
-    py310-previous
-    py37-legacy
+    py312-lts
+    py311-lts
 commands =
   coverage combine
   coverage html


### PR DESCRIPTION
# Django 5.2 Compatibility Update
## Overview
This PR updates django-countries to support Django 5.2 while modernizing the test infrastructure and dropping support for older versions. This is a major version bump to 8.0 due to the removal of support for Django versions before 4.2 and Python versions before 3.11.

## Changes
### Version Support

- Added support for Django 5.2
- Dropped support for Django versions before 4.2
- Dropped support for Python versions before 3.11
- Added explicit support for Python 3.12

### Testing Infrastructure

- Updated tox configuration to test against:
- Django 5.2 (latest) with Python 3.11 and 3.12
- Django 4.2 (LTS) with Python 3.11 and 3.12
- Removed test environments for deprecated Django/Python combinations
- Updated GitHub Actions workflow to test only on Python 3.11 and 3.12

### Package Metadata

- Bumped version to 8.0.dev0
- Updated Python and Django version classifiers in setup.cfg
- Maintained all existing test configurations for supported versions

### Breaking Changes

- Removed support for Django 3.2, 4.0, and 4.1
- Removed support for Python 3.7, 3.8, 3.9, and 3.10
- Projects using these versions will need to either upgrade their Python/Django versions or continue using django-countries 7.x

### Compatibility Matrix
| Django Version | Python 3.11 | Python 3.12 |
|---------------|-------------|-------------|
| 5.2 | ✅ | ✅ |
| 4.2 (LTS) | ✅ | ✅ |

